### PR TITLE
adds useContext hook and configures with FeedbackList

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -34,7 +34,7 @@ function App() {
               <>             
                 <FeedbackForm handleAdd={addFeedback} />
                 <FeedbackStats feedback={feedback} />
-                <FeedbackList feedback={feedback} handleDelete={deleteFeedback} />
+                <FeedbackList handleDelete={deleteFeedback} />
               </>
             }>        
             </Route>

--- a/src/components/FeedbackList.js
+++ b/src/components/FeedbackList.js
@@ -1,9 +1,11 @@
-import React from 'react';
+import React, { useContext } from 'react';
 import FeedbackItem from './FeedbackItem';
 import { motion, AnimatePresence } from 'framer-motion';
-import PropTypes from 'prop-types';
+import FeedbackContext from '../context/FeedbackContext';
 
-function FeedbackList({feedback, handleDelete}) {
+function FeedbackList({handleDelete}) {
+    const {feedback} = useContext(FeedbackContext);
+
     if(!feedback || feedback.length === 0) {
         return (
             <p>There is no feedback yet!</p>
@@ -35,15 +37,5 @@ function FeedbackList({feedback, handleDelete}) {
         </div>
     )
 };
-
-FeedbackList.propTypes = {
-    feedback: PropTypes.arrayOf(
-        PropTypes.shape({
-            // id: PropTypes.number.isRequired,
-            text: PropTypes.string.isRequired,
-            rating: PropTypes.number.isRequired
-        })
-    )
-}
 
 export default FeedbackList;


### PR DESCRIPTION
In the `components/FeedbackList` file, the `useContext` hook is imported in from `react`. Also, `FeedbackContext` is imported in from `context/FeedbackContext`. In the `FeedbackList` function, the `feedback` prop is removed as a parameter. A variable is then declared that extracts `feedback` from the context it accesses, which is set equal to `useContext` that takes in `FeedbackContext`. Since the `feedback` prop is no longer being used, the `propTypes` data is removed from the bottom of the component. Also, the `PropTypes` import at the top is removed.

In the `App.js` file, inside the `return`, the `FeedbackList` element has the `feedback` prop removed, as it's no longer accessing state this way.