### PR TITLE
configures useContext hook with FeedbackStats

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -33,7 +33,7 @@ function App() {
             <Route exact path='/' element={
               <>             
                 <FeedbackForm handleAdd={addFeedback} />
-                <FeedbackStats feedback={feedback} />
+                <FeedbackStats />
                 <FeedbackList handleDelete={deleteFeedback} />
               </>
             }>        

--- a/src/components/FeedbackStats.js
+++ b/src/components/FeedbackStats.js
@@ -1,7 +1,9 @@
-import React from 'react';
-import PropTypes from 'prop-types';
+import React, { useContext } from 'react';
+import FeedbackContext from '../context/FeedbackContext';
 
-function FeedbackStats({feedback}) {
+function FeedbackStats() {
+    const {feedback} = useContext(FeedbackContext);
+
     // Calculate ratings average
     let average = feedback.reduce((acc, cur) => {
         return acc + cur.rating
@@ -13,15 +15,11 @@ function FeedbackStats({feedback}) {
 
     return (
         <div className="feedback-stats">
-            <h4>{feedback.length} Reviews</h4>
+            <h4>{feedback.length} {feedback.length === 1 ? "Review" : "Reviews"}</h4>
             {/* Display 0 if NaN */}
             <h4>Average Rating: {isNaN(average) ? 0 : average}</h4>
         </div>
     )
-}
-
-FeedbackStats.propTypes = {
-    feedback: PropTypes.array.isRequired
 }
 
 export default FeedbackStats;

--- a/src/context/FeedbackContext.js
+++ b/src/context/FeedbackContext.js
@@ -18,4 +18,4 @@ export const FeedbackProvider = ({children}) => {
     </FeedbackContext.Provider>
 }
 
-export default FeedbackContext; 
+export default FeedbackContext;


### PR DESCRIPTION
In the `components/FeedbackStats.js` file, `useContext` is imported from React. Also, `FeedbackContext` is imported.  Then in the function, the `feedback` state is accessed from the `FeedbackContext` using `useContext`. Due to accessing state through context, the `PropTypes` is removed from the imports, and the `propTypes` configuration at the bottom is removed as well.  An update is also made to the `<h4>` in the `return`, to account for the text if the ratings are singular. A ternary operator is added, so that if the ratings length is strictly equal to 1, then the text reads as "Review". Otherwise, the text will read as "Reviews".

In the `App.js` file, in the `FeedbackStats` component element in the `return`, the `feedback` prop is removed, as it's now accessing state through Context.