### PR TITLE
refactors deleteFeedback function to be used with context

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -18,12 +18,6 @@ function App() {
       setFeedback([newFeedback, ...feedback]);
   }
 
-  const deleteFeedback = (id) => {
-    if(window.confirm("Are you sure you want to delete this item?")) {
-      setFeedback(feedback.filter((item) => item.id !== id))
-    }
-  };
-
   return (        
     <FeedbackProvider>
       <Router>
@@ -34,7 +28,7 @@ function App() {
               <>             
                 <FeedbackForm handleAdd={addFeedback} />
                 <FeedbackStats />
-                <FeedbackList handleDelete={deleteFeedback} />
+                <FeedbackList />
               </>
             }>        
             </Route>

--- a/src/components/FeedbackItem.js
+++ b/src/components/FeedbackItem.js
@@ -1,13 +1,16 @@
 import { FaTimes } from 'react-icons/fa';
+import { useContext } from 'react';
 import PropTypes from 'prop-types';
 import Card from './shared/Card';
+import FeedbackContext from '../context/FeedbackContext';
 
+function FeedbackItem ({item}) {
+    const {deleteFeedback} = useContext(FeedbackContext);
 
-function FeedbackItem ({item, handleDelete}) {
     return (
         <Card>
             <div className="num-display">{item.rating}</div>
-            <button onClick={ () => handleDelete(item.id) } className="close">
+            <button onClick={ () => deleteFeedback(item.id) } className="close">
                 <FaTimes color="purple" />
             </button>
             <div className="text-display">{item.text}</div>

--- a/src/components/FeedbackList.js
+++ b/src/components/FeedbackList.js
@@ -3,7 +3,7 @@ import FeedbackItem from './FeedbackItem';
 import { motion, AnimatePresence } from 'framer-motion';
 import FeedbackContext from '../context/FeedbackContext';
 
-function FeedbackList({handleDelete}) {
+function FeedbackList() {
     const {feedback} = useContext(FeedbackContext);
 
     if(!feedback || feedback.length === 0) {
@@ -28,8 +28,7 @@ function FeedbackList({handleDelete}) {
                     >
                         <FeedbackItem 
                             key={item.id} 
-                            item={item} 
-                            handleDelete={handleDelete}
+                            item={item}
                         />
                     </motion.div>
                 ))}            

--- a/src/context/FeedbackContext.js
+++ b/src/context/FeedbackContext.js
@@ -3,7 +3,7 @@ import { createContext, useState } from 'react';
 const FeedbackContext = createContext();
 
 export const FeedbackProvider = ({children}) => {
-    const [feedback, setfeedback] = useState([
+    const [feedback, setFeedback] = useState([
         {
             id: 1,
             text: 'This text is coming from Context',
@@ -11,8 +11,15 @@ export const FeedbackProvider = ({children}) => {
         }
     ]);
 
+    const deleteFeedback = (id) => {
+        if(window.confirm("Are you sure you want to delete this item?")) {
+            setFeedback(feedback.filter((item) => item.id !== id))
+        }
+    };
+
     return <FeedbackContext.Provider value={{
         feedback,
+        deleteFeedback,
     }}>
         {children}
     </FeedbackContext.Provider>


### PR DESCRIPTION
In the `App.js` file, the `deleteFeedback` function is removed. Also in the `return`, the `handleDelete` prop is removed that was calling that function. 

In the `context/FeedbackContext.js` file, the `deleteFeedback` function is then added to the context. This function is also added as a `value` in the `return` of the provider.

In the `FeedbackList.js` file, the `handleDelete` parameter is removed, since it's no longer being used within the component. It's also removed as a prop from the `<FeedbackItem>` that's used in the `return`.

In the `FeedbackItem.js` file, `useContext` is imported from 'react', and the `FeedbackContext` is imported as well. In the component's function, the `handledelete` parameter is removed, since it's no longer being used within the component. Then for the `<button>` in the `return`, the `handleDelete` prop is now removed, and replaced with `deleteFeedback` that is coming from the context.

