### PR TITLE
refactors addFeedback function to be used with context

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -1,9 +1,7 @@
-import {v4 as uuidv4} from 'uuid';
-import React, {useState} from 'react';
+import React from 'react';
 import {BrowserRouter as Router, Route, Routes} from 'react-router-dom';
 import Header from './components/Header';
 import FeedbackList from './components/FeedbackList';
-import FeedbackData from './data/FeedbackData';
 import FeedbackStats from './components/FeedbackStats';
 import FeedbackForm from './components/FeedbackForm';
 import AboutPage from './pages/AboutPage';
@@ -11,13 +9,6 @@ import AboutIconLink from './components/AboutIconLink';
 import {FeedbackProvider} from './context/FeedbackContext';
 
 function App() {
-  const [feedback, setFeedback] = useState(FeedbackData);
-
-  const addFeedback = (newFeedback) => {
-      newFeedback.id = uuidv4();
-      setFeedback([newFeedback, ...feedback]);
-  }
-
   return (        
     <FeedbackProvider>
       <Router>
@@ -26,7 +17,7 @@ function App() {
           <Routes>
             <Route exact path='/' element={
               <>             
-                <FeedbackForm handleAdd={addFeedback} />
+                <FeedbackForm />
                 <FeedbackStats />
                 <FeedbackList />
               </>

--- a/src/components/FeedbackForm.js
+++ b/src/components/FeedbackForm.js
@@ -1,13 +1,16 @@
-import React, {useState} from 'react';
+import React, {useState, useContext} from 'react';
 import Card from './shared/Card';
 import Button from './shared/Button';
 import RatingSelect from './RatingSelect';
+import FeedbackContext from '../context/FeedbackContext';
 
-function FeedbackForm({handleAdd}) {
+function FeedbackForm() {
     const [text, setText] = useState('');
     const [rating, setRating] = useState(10);
     const [btnDisabled, setBtnDisabled] = useState(true);
     const [message, setMessage] = useState('');
+
+    const {addFeedback} = useContext(FeedbackContext);
 
     const handleTextChange = (e) => {
         if(text === "") {
@@ -33,7 +36,7 @@ function FeedbackForm({handleAdd}) {
                 text,
                 rating,
             }
-            handleAdd(newFeedback);
+            addFeedback(newFeedback);
 
             setText('');
         }

--- a/src/context/FeedbackContext.js
+++ b/src/context/FeedbackContext.js
@@ -1,3 +1,4 @@
+import {v4 as uuidv4} from 'uuid';
 import { createContext, useState } from 'react';
 
 const FeedbackContext = createContext();
@@ -6,10 +7,25 @@ export const FeedbackProvider = ({children}) => {
     const [feedback, setFeedback] = useState([
         {
             id: 1,
-            text: 'This text is coming from Context',
+            text: 'This is feedback item 1',
             rating: 10
+        },
+        {
+            id: 2,
+            text: 'This is feedback item 2',
+            rating: 8
+        },
+        {
+            id: 3,
+            text: 'This is feedback item 3',
+            rating: 4
         }
     ]);
+
+    const addFeedback = (newFeedback) => {
+        newFeedback.id = uuidv4();
+        setFeedback([newFeedback, ...feedback]);
+    }
 
     const deleteFeedback = (id) => {
         if(window.confirm("Are you sure you want to delete this item?")) {
@@ -19,6 +35,7 @@ export const FeedbackProvider = ({children}) => {
 
     return <FeedbackContext.Provider value={{
         feedback,
+        addFeedback,
         deleteFeedback,
     }}>
         {children}


### PR DESCRIPTION
In the `App.js` file, the `addFeedback` function was cut from the code. The `handleAdd` prop that set to equal this function was also removed from the `<FeedbackForm>` element. While here, the `useState` was removed from the component, and from the `import` at the top. The `FeedbackData` was also removed as an `import`.

In the `context/FeedbackContext` file, the `addFeedback` function is added to the component. Also, the `import` for the `uuid` package was brought over from `App.js`. In the state, the object was changed to say "This is feedback item 1". Then two similar additional objects were added for item 2 and item 3, along with ratings. In the `return`, `addFeedback` was added here as an additional `value`.

In `FeedbackForm.js`, the `handleAdd` was removed as a parameter from the component's function. Then the context was brought in by importing the `useContext` hook from React, as well as importing `FeedbackContext` from `/context/FeedbackContext`.  In the function, `useContext` was used with `FeedbackContext` passed in, and this was set to use the `addFeedback` parameter. In the `handleTextChange` function, `addFeedback` was used to replace `handleAdd`. 