### PR TITLE
configures app to allow submission for updated feedback item

### DIFF
--- a/src/components/FeedbackForm.js
+++ b/src/components/FeedbackForm.js
@@ -10,12 +10,14 @@ function FeedbackForm() {
     const [btnDisabled, setBtnDisabled] = useState(true);
     const [message, setMessage] = useState('');
 
-    const { addFeedback, feedbackEdit } = useContext(FeedbackContext);
+    const { addFeedback, feedbackEdit, updateFeedback } = useContext(FeedbackContext);
 
     useEffect(() => {
-        setBtnDisabled(false);
-        setText(feedbackEdit.item.text);
-        setRating(feedbackEdit.item.rating);
+        if(feedbackEdit.edit === true) {
+            setBtnDisabled(false);
+            setText(feedbackEdit.item.text);
+            setRating(feedbackEdit.item.rating);
+        }
     }, [feedbackEdit]);
 
     const handleTextChange = (e) => {
@@ -42,7 +44,14 @@ function FeedbackForm() {
                 text,
                 rating,
             }
-            addFeedback(newFeedback);
+
+            if(feedbackEdit.edit === true) {
+                updateFeedback(feedbackEdit.item.id, newFeedback);
+                
+            }
+            else {
+                addFeedback(newFeedback);    
+            }            
 
             setText('');
         }

--- a/src/context/FeedbackContext.js
+++ b/src/context/FeedbackContext.js
@@ -48,12 +48,24 @@ export const FeedbackProvider = ({children}) => {
         })
     }
 
+    // update feedback item
+    const updateFeedback = (id, updateItem) => {
+        setFeedback(feedback.map((item) => (item.id === id ? 
+            {...item, ...updateItem} : item))
+        )
+        setFeedbackEdit({
+            item: {},
+            edit: false,
+        })
+    }
+
     return <FeedbackContext.Provider value={{
         feedback,
+        feedbackEdit,
         addFeedback,
         deleteFeedback,
         editFeedback,
-        feedbackEdit,
+        updateFeedback
     }}>
         {children}
     </FeedbackContext.Provider>


### PR DESCRIPTION
In `context/FeedbackContext.js`, a function called `updateFeedback` is added. There are 2 parameters passed in: an `id` and a `updateItem`. The function then sets the `setFeedback` value by mapping over the `feedback` in the state. For each `item`, the `item.id` is compared to the `id` being passed into the function. If they match, the result is a spread of the `item`, and a spread of the `updateItem`. Otherwise, the `item` is simply returned. Also within the overall function, the `setFeedbackEdit` is reset to be an empty object with the `edit` boolean set to "false". Also, in the `Provider`, this new `updateFeedback` function was added as a `value`.

In `FeedbackForm.js`, the `updateFeedback` function is pulled in from `FeedbackContext`. Then in the `handleTextChange` function, a conditional is added. It checks `if` the `feedbackEdit.edit` is set to "true", then the `updateFeedback` function is ran. The 2 arguments provided here are `feedbackEdit.item.id` and then the `newFeedback`. Then `else` is ran if `feedbackEdit.edit` is "false", in which `addFeedback` with `newFeedback` passed in.  

Also, in the `useEffect` function, a conditional was wrapped around the code. It checks `if` the `feedbackEdit.edit` is set to "true". Only if this is true, will the various states contained within be updated.