### PR TITLE
adjusts CSS for styling of form input section

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -41,9 +41,15 @@ header {
   background-color: #fff;
   color: #333;
   border-radius: 15px;
-  padding: 40px 50px;
+  padding: 40px 15px;
   margin: 20px 0;
   position: relative;
+}
+
+@media (min-width: 760px) {
+  .card {
+    padding: 40px 50px;
+  }
 }
 
 .card.reverse {
@@ -107,16 +113,32 @@ header {
 
 .input-group {
   display: flex;
-  flex-direction: row;
+  flex-direction: column;
+  align-items: center;
   border: 1px solid #ccc;
   padding: 8px 10px;
   border-radius: 8px;
+}
+
+@media (min-width: 760px) {
+  .input-group {
+    flex-direction: row;
+  }
 }
 
 input {
   flex-grow: 2;
   border: none;
   font-size: 16px;
+  margin-bottom: 10px;
+  text-align: center;
+}
+
+@media (min-width: 760px) {
+  input {
+    margin-bottom: 0;
+    text-align: start;
+  }
 }
 
 input:focus {
@@ -164,6 +186,12 @@ input:focus {
   background-color: #202142;
 }
 
+@media (min-width: 760px) {
+  .btn-primary {
+    order: 3;
+  }
+}
+
 .btn-secondary {
   background: #ff6a95;
 }
@@ -185,9 +213,23 @@ input:focus {
 }
 
 .message {
-  padding-top: 10px;
+  padding-top: 5px;
   text-align: center;
   color: rebeccapurple;
+}
+
+@media (max-width: 375px) {
+  .message {
+    font-size: 15px;
+  }
+}
+
+@media (min-width: 760px) {
+  .message {
+    order: 2;
+    margin-right: 20px;
+    padding-top: 0;
+  }
 }
 
 /* FIX: Remove position: absolute to keep about icon at the bottom of the
@@ -235,7 +277,7 @@ input:focus {
   }
 
   .input-group input {
-    width: 80%;
+    /* width: 80%; */
   }
 }
 


### PR DESCRIPTION
In the `index.css` file: 

The class of `.card` has it's "padding" set for right/left to be "15px" on mobile. Then at the breakpoint of "760px", it's set to "50px". 

The class of `input-group` has its "flex-direction" set to "column" for mobile, and the "align-items" is set to "center". Then at the breakpoint of "760px", it's set to to "row". 

For the class of `.input`, the text is centered and it's given a "margin-bottom" of "10px". Then at the breakpoint of "760px", its "margin-bottom" is set to "0", and the "text-align" is set to "start".

For the class of `btn-primary`, at the breakpoint of "760px", its order is changed to 3.

For the class of `.message`, the "padding-top" is slightly reduced to "5px". The "font-size" is set to stay at "15px" until the breakpoint at "375px" (at which it defaults back to "16px". Then at the breakpoint of "760px", it's given an "order" of "2", and its "margin-right" and "padding-top" are adjusted.

For the class of `input-group input`, the "width" of "80%" is removed.
